### PR TITLE
Option lists require consistent ordering

### DIFF
--- a/slack/blocks.go
+++ b/slack/blocks.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"crypto/sha1"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/slack-go/slack"
@@ -198,6 +199,7 @@ func (b *Blocks) addSelect(text string, options []spanner.Option) (inputBlockID 
 	for _, option := range options {
 		values = append(values, option.Value)
 	}
+	sort.Strings(values)
 	optionHash := hashstr(strings.Join(values, ","))
 
 	inputBlockID = fmt.Sprintf("input-%v-%v", b.inputID, optionHash)


### PR DESCRIPTION
Fixes #1

Sort the values before generating the hash.

Tested by building the units list from a map to randomize the order. Verified that the selected value was retained even if the order changed, but different sets of values still resulted in the selection being cleared.