### PR TITLE
Add unit tests for getting started example

### DIFF
--- a/slack/app_test.go
+++ b/slack/app_test.go
@@ -76,30 +76,44 @@ func (r *runSocketClient) RunContext(context.Context) error {
 
 func (*runSocketClient) Ack(req socketmode.Request, payload ...interface{}) {}
 
-func messageEvent(channelID, userID, text string) socketmode.Event {
+func messageEvent(messageEvent slackevents.MessageEvent) socketmode.Event {
 	return socketmode.Event{
 		Type: socketmode.EventTypeEventsAPI,
 		Data: slackevents.EventsAPIEvent{
 			Type: slackevents.CallbackEvent,
 			InnerEvent: slackevents.EventsAPIInnerEvent{
-				Data: &slackevents.MessageEvent{
-					Text:    text,
-					User:    userID,
-					Channel: channelID,
-				},
+				Data: &messageEvent,
 			},
 		},
 	}
 }
 
-func slashCommandEvent(channelID, userID, triggerID, command string) socketmode.Event {
+func slashCommandEvent(data slack.SlashCommand) socketmode.Event {
 	return socketmode.Event{
 		Type: socketmode.EventTypeSlashCommand,
-		Data: slack.SlashCommand{
-			ChannelID: channelID,
-			UserID:    userID,
-			TriggerID: triggerID,
-			Command:   command,
+		Data: data,
+	}
+}
+
+func messageInteractionEvent(
+	hash string,
+	metadata slack.SlackMetadata,
+	actionCallbacks slack.ActionCallbacks,
+	blockActionState *slack.BlockActionStates,
+) socketmode.Event {
+	return socketmode.Event{
+		Type: socketmode.EventTypeInteractive,
+		Data: slack.InteractionCallback{
+			ViewSubmissionCallback: slack.ViewSubmissionCallback{
+				Hash: hash,
+			},
+			Message: slack.Message{
+				Msg: slack.Msg{
+					Metadata: metadata,
+				},
+			},
+			ActionCallback:   actionCallbacks,
+			BlockActionState: blockActionState,
 		},
 	}
 }

--- a/slack/examples_test.go
+++ b/slack/examples_test.go
@@ -1,0 +1,152 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+	"github.com/theothertomelliott/spanner"
+)
+
+// TestGettingStarted verifies that the code in examples/gettingstarted
+// interacts with Slack in the expected way
+func TestGettingStarted(t *testing.T) {
+	slackEvents := make(chan socketmode.Event)
+	client := newExampleTestClient()
+
+	testApp := newAppWithClient(
+		client,
+		slackEvents,
+	)
+
+	go func() {
+		err := testApp.Run(handler)
+		if err != nil {
+			t.Errorf("error running app: %v", err)
+		}
+	}()
+
+	// Send hello message
+	slackEvents <- messageEvent(
+		slackevents.MessageEvent{
+			Text:    "hello",
+			Channel: "ABC123",
+			User:    "DEF456",
+		},
+	)
+
+	firstMetadata, firstBlocks, err := expectOneMessage(client.messagesSent, "ABC123")
+	if err != nil {
+		t.Errorf("receiving first message: %v", err)
+	}
+	if !strings.Contains(firstBlocks, `Hello to you too: `) {
+		t.Errorf("first message content was not as expected, got: %v", string(firstBlocks))
+	}
+
+	slackEvents <- messageInteractionEvent(
+		"hash",
+		firstMetadata,
+		slack.ActionCallbacks{},
+		&slack.BlockActionStates{
+			Values: map[string]map[string]slack.BlockAction{
+				fmt.Sprintf("input-0-%v", hashstr(strings.Join([]string{"a", "b", "c"}, ","))): {
+					"x": slack.BlockAction{
+						SelectedOption: slack.OptionBlockObject{
+							Value: "c",
+						},
+					},
+				},
+			},
+		},
+	)
+
+	_, secondBlocks, err := expectOneMessage(client.messagesSent, "ABC123")
+	if err != nil {
+		t.Errorf("receiving second message: %v", err)
+	}
+	if !strings.Contains(secondBlocks, `You chose \"c\"`) {
+		t.Errorf("message content was not as expected, got: %v", secondBlocks)
+	}
+}
+
+// expectOneMessage checks for a single message being sent on the expected channel
+// it returns the metadata and the JSON form of the message's blocks.
+func expectOneMessage(messages chan sentMessage, channelID string) (slack.SlackMetadata, string, error) {
+	var message sentMessage
+	select {
+	case message = <-messages:
+	case <-time.After(time.Second):
+		return slack.SlackMetadata{}, "", fmt.Errorf("timed out waiting for expected message")
+	}
+
+	// Ensure only one message was sent
+	select {
+	case <-messages:
+		return slack.SlackMetadata{}, "", fmt.Errorf("expected exactly one message")
+	case <-time.After(time.Second / 100):
+	}
+
+	blockJson, err := json.MarshalIndent(message.blocks, "", "  ")
+	if err != nil {
+		return slack.SlackMetadata{}, "", fmt.Errorf("could not marshal block data: %v", err)
+	}
+
+	return message.metadata, string(blockJson), nil
+}
+
+// handler should be kept in sync with README.md and examples/gettingstarted/main.go
+func handler(ev spanner.Event) error {
+	if msg := ev.ReceiveMessage(); msg != nil && msg.Text() == "hello" {
+		reply := ev.SendMessage(msg.Channel().ID())
+		reply.PlainText(fmt.Sprintf("Hello to you too: %v", msg.User()))
+
+		letter := reply.Select("Pick a letter", spanner.Options("a", "b", "c"))
+		if letter != "" {
+			ev.SendMessage(msg.Channel().ID()).PlainText(fmt.Sprintf("You chose %q", letter))
+		}
+	}
+	return nil
+}
+
+func newExampleTestClient() *exampleTestClient {
+	return &exampleTestClient{
+		messagesSent: make(chan sentMessage),
+		stop:         make(chan struct{}),
+	}
+}
+
+type exampleTestClient struct {
+	nilSocketClient
+
+	messagesSent chan sentMessage
+
+	stop chan struct{}
+}
+
+type sentMessage struct {
+	channelID string
+	blocks    []slack.Block
+	metadata  slack.SlackMetadata
+}
+
+func (r *exampleTestClient) RunContext(context.Context) error {
+	<-r.stop // Must block
+	return nil
+}
+
+func (*exampleTestClient) Ack(req socketmode.Request, payload ...interface{}) {}
+
+func (c *exampleTestClient) SendMessageWithMetadata(ctx context.Context, channelID string, blocks []slack.Block, metadata slack.SlackMetadata) (string, string, string, error) {
+	c.messagesSent <- sentMessage{
+		channelID: channelID,
+		blocks:    blocks,
+		metadata:  metadata,
+	}
+	return "", "", "", nil
+}

--- a/slack/message.go
+++ b/slack/message.go
@@ -46,17 +46,17 @@ func (m *message) Channel(channelID string) {
 
 func (m *message) finishEvent(req request) error {
 	if m.unsent {
-		_, _, _, err := req.client.SendMessageContext(
+		_, _, _, err := req.client.SendMessageWithMetadata(
 			context.TODO(),
 			m.ChannelID,
-			slack.MsgOptionBlocks(m.blocks...),
-			slack.MsgOptionMetadata(slack.SlackMetadata{
+			m.blocks,
+			slack.SlackMetadata{
 				EventType: "bot_message",
 				EventPayload: map[string]interface{}{
 					"message_index": m.MessageIndex,
 					"metadata":      string(req.Metadata()),
 				},
-			}))
+			})
 		if err != nil {
 			return fmt.Errorf("sending message: %w", renderSlackError(err))
 		}

--- a/slack/receivemessage_test.go
+++ b/slack/receivemessage_test.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"testing"
 
+	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
 	"github.com/theothertomelliott/spanner"
 )
@@ -16,14 +17,12 @@ func TestReceiveMessageContent(t *testing.T) {
 		slackEvents,
 	)
 
-	expectedChannelID := "ABC123"
-	expectedUserID := "DEF456"
-	expectedText := "hello, there"
-	slackEvents <- messageEvent(
-		expectedChannelID,
-		expectedUserID,
-		expectedText,
-	)
+	message := slackevents.MessageEvent{
+		Channel: "ABC123",
+		User:    "DEF456",
+		Text:    "hello, there",
+	}
+	slackEvents <- messageEvent(message)
 
 	testApp.Run(func(evt spanner.Event) error {
 		defer func() {
@@ -37,14 +36,14 @@ func TestReceiveMessageContent(t *testing.T) {
 			t.Errorf("expected a ReceiveMessage event")
 			return nil
 		}
-		if msg.Channel().ID() != expectedChannelID {
-			t.Errorf("expected channel id %q, got %q", expectedChannelID, msg.Channel().ID())
+		if msg.Channel().ID() != message.Channel {
+			t.Errorf("expected channel id %q, got %q", message.Channel, msg.Channel().ID())
 		}
-		if msg.User().ID() != expectedUserID {
-			t.Errorf("expected user id %q, got %q", expectedChannelID, msg.User().ID())
+		if msg.User().ID() != message.User {
+			t.Errorf("expected user id %q, got %q", message.User, msg.User().ID())
 		}
-		if msg.Text() != expectedText {
-			t.Errorf("expected text %q, got %q", expectedText, msg.Text())
+		if msg.Text() != message.Text {
+			t.Errorf("expected text %q, got %q", message.Text, msg.Text())
 		}
 
 		return nil

--- a/slack/receiveslashcommand_test.go
+++ b/slack/receiveslashcommand_test.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"testing"
 
+	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/socketmode"
 	"github.com/theothertomelliott/spanner"
 )
@@ -16,14 +17,14 @@ func TestReceiveSlashCommand(t *testing.T) {
 		slackEvents,
 	)
 
-	expectedChannelID := "ABC123"
-	expectedUserID := "DEF456"
-	expectedCommand := "/mycommand"
+	slashCommand := slack.SlashCommand{
+		ChannelID: "ABC123",
+		UserID:    "DEF456",
+		TriggerID: "trigger",
+		Command:   "/mycommand",
+	}
 	slackEvents <- slashCommandEvent(
-		expectedChannelID,
-		expectedUserID,
-		"trigger",
-		expectedCommand,
+		slashCommand,
 	)
 
 	testApp.Run(func(evt spanner.Event) error {
@@ -33,16 +34,16 @@ func TestReceiveSlashCommand(t *testing.T) {
 		}()
 
 		// Expect a slash command with the expected command is received
-		cmd := evt.ReceiveSlashCommand(expectedCommand)
+		cmd := evt.ReceiveSlashCommand(slashCommand.Command)
 		if cmd == nil {
 			t.Errorf("expected a ReceiveSlashCommand event")
 			return nil
 		}
-		if cmd.Channel().ID() != expectedChannelID {
-			t.Errorf("expected channel id %q, got %q", expectedChannelID, cmd.Channel().ID())
+		if cmd.Channel().ID() != slashCommand.ChannelID {
+			t.Errorf("expected channel id %q, got %q", slashCommand.ChannelID, cmd.Channel().ID())
 		}
-		if cmd.User().ID() != expectedUserID {
-			t.Errorf("expected user id %q, got %q", expectedChannelID, cmd.User().ID())
+		if cmd.User().ID() != slashCommand.UserID {
+			t.Errorf("expected user id %q, got %q", slashCommand.UserID, cmd.User().ID())
 		}
 
 		return nil

--- a/slack/slackclient.go
+++ b/slack/slackclient.go
@@ -220,8 +220,11 @@ type socketClient interface {
 	// SearchMessagesContext(ctx context.Context, query string, params SearchParameters) (*SearchMessages, error)
 	// SendAuthRevoke(token string) (*AuthRevokeResponse, error)
 	// SendAuthRevokeContext(ctx context.Context, token string) (*AuthRevokeResponse, error)
-	//SendMessage(channel string, options ...slack.MsgOption) (string, string, string, error)
-	SendMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (_channel string, _timestamp string, _text string, err error)
+
+	SendMessageWithMetadata(ctx context.Context, channel string, blocks []slack.Block, metadata slack.SlackMetadata) (string, string, string, error)
+	// SendMessage(channel string, options ...slack.MsgOption) (string, string, string, error)
+	// SendMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (_channel string, _timestamp string, _text string, err error)
+
 	// SendSSOBindingEmail(teamName string, user string) error
 	// SendSSOBindingEmailContext(ctx context.Context, teamName string, user string) error
 	// SetPurposeOfConversation(channelID string, purpose string) (*Channel, error)
@@ -324,8 +327,8 @@ func (nilSocketClient) RunContext(ctx context.Context) error {
 	panic("unimplemented")
 }
 
-// SendMessageContext implements socketClient.
-func (nilSocketClient) SendMessageContext(ctx context.Context, channelID string, options ...slack.MsgOption) (_channel string, _timestamp string, _text string, err error) {
+// SendMessageWithMetadata implements socketClient.
+func (nilSocketClient) SendMessageWithMetadata(ctx context.Context, channel string, blocks []slack.Block, metadata slack.SlackMetadata) (string, string, string, error) {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
Allows testing of receiving and sending messages.
Adds helper functions for common test actions.

Partial fix for #2