### PR TITLE
Support ephemeral messages in response to slash commands

### DIFF
--- a/api.go
+++ b/api.go
@@ -40,6 +40,7 @@ type ModalCreator interface {
 // SlashCommand represents a received slash command.
 // Messages and modal views may be created in response to the command.
 type SlashCommand interface {
+	EphemeralSender
 	Metadata
 	ModalCreator
 }
@@ -62,6 +63,10 @@ type ModalSubmission interface {
 type ReceivedMessage interface {
 	Metadata
 	Text() string
+}
+
+type EphemeralSender interface {
+	SendEphemeralMessage(text string)
 }
 
 // Message represents a message that can be sent to Slack.

--- a/examples/gallery/main.go
+++ b/examples/gallery/main.go
@@ -31,6 +31,10 @@ func main() {
 			ev.JoinChannel("C016E85HUUA") // #random channel from QA workspace
 		}
 
+		if testSlash := ev.ReceiveSlashCommand("/testslash"); testSlash != nil {
+			testSlash.SendEphemeralMessage("This should be only visible to you")
+		}
+
 		if msg := ev.ReceiveMessage(); msg != nil && msg.Text() == "hello" {
 
 			reply := ev.SendMessage(msg.Channel().ID())

--- a/slack/ephemeral.go
+++ b/slack/ephemeral.go
@@ -1,0 +1,29 @@
+package slack
+
+import (
+	"github.com/theothertomelliott/spanner"
+)
+
+var _ spanner.EphemeralSender = &ephemeralSender{}
+
+type ephemeralSender struct {
+	Text *string `json:"ephemeral"`
+}
+
+// SendEphemeralMessage implements spanner.EphemeralSender.
+func (es *ephemeralSender) SendEphemeralMessage(text string) {
+	es.Text = &text
+}
+
+func (es *ephemeralSender) finishEvent(req request) error {
+	payload := map[string]interface{}{
+		"text": es.Text,
+	}
+	req.client.Ack(req.req, payload)
+
+	return nil
+}
+
+func (es *ephemeralSender) populateEvent(p eventPopulation) error {
+	return nil
+}

--- a/slack/modal.go
+++ b/slack/modal.go
@@ -153,6 +153,7 @@ var _ spanner.ModalSubmission = &modalSubmission{}
 type modalSubmission struct {
 	NextModal *modal `json:"next_modal"`
 
+	ephemeralSender
 	parent *modal
 }
 
@@ -174,6 +175,9 @@ func (m *modalSubmission) finishEvent(req request) error {
 	if m.NextModal != nil {
 		return m.NextModal.finishEvent(req)
 	}
+	if m.ephemeralSender.Text != nil {
+		return m.ephemeralSender.finishEvent(req)
+	}
 
 	var payload interface{} = map[string]interface{}{}
 	payload = slack.NewClearViewSubmissionResponse()
@@ -185,6 +189,9 @@ func (m *modalSubmission) finishEvent(req request) error {
 func (m *modalSubmission) populateEvent(p eventPopulation) error {
 	if m.NextModal != nil {
 		return m.NextModal.populateEvent(p)
+	}
+	if m.ephemeralSender.Text != nil {
+		return m.ephemeralSender.populateEvent(p)
 	}
 
 	return nil

--- a/slack/slashcommand.go
+++ b/slack/slashcommand.go
@@ -4,6 +4,7 @@ import "github.com/theothertomelliott/spanner"
 
 type slashCommand struct {
 	eventMetadata
+	ephemeralSender
 
 	TriggerID     string `json:"trigger_id"`
 	Command       string `json:"command"`
@@ -32,12 +33,22 @@ func (is *slashCommand) finishEvent(req request) error {
 	if is.ModalInternal != nil {
 		return is.ModalInternal.finishEvent(req)
 	}
+	if is.ephemeralSender.Text != nil {
+		return is.ephemeralSender.finishEvent(req)
+	}
+
+	var payload interface{} = map[string]interface{}{}
+	req.client.Ack(req.req, payload)
+
 	return nil
 }
 
 func (is *slashCommand) populateEvent(p eventPopulation) error {
 	if is.ModalInternal != nil {
 		return is.ModalInternal.populateEvent(p)
+	}
+	if is.ephemeralSender.Text != nil {
+		return is.ephemeralSender.populateEvent(p)
 	}
 	return nil
 }


### PR DESCRIPTION
This seems to be the only form supported in an ack.

There is a Slack API for this: https://api.slack.com/methods/chat.postEphemeral
So the approach could change in future.

Fixes #15