### PR TITLE
Identify messages for updating by depth and index, not timestamp

### DIFF
--- a/slack/ephemeral.go
+++ b/slack/ephemeral.go
@@ -24,6 +24,6 @@ func (es *ephemeralSender) finishEvent(req request) error {
 	return nil
 }
 
-func (es *ephemeralSender) populateEvent(p eventPopulation) error {
+func (es *ephemeralSender) populateEvent(p eventPopulation, depth int) error {
 	return nil
 }

--- a/slack/event.go
+++ b/slack/event.go
@@ -119,6 +119,7 @@ type eventPopulation struct {
 	interactionCallbackEvent slack.InteractionCallback
 	interaction              slack.InteractionType
 	messageIndex             string
+	interactionDepth         int
 }
 
 func parseCombinedEvent(client socketClient, ce combinedEvent) *event {
@@ -247,6 +248,7 @@ func parseCombinedEvent(client socketClient, ce combinedEvent) *event {
 						interaction:              interactionCallbackEvent.Type,
 						messageIndex:             "",
 					},
+					0,
 				)
 			}
 
@@ -263,13 +265,13 @@ func parseCombinedEvent(client socketClient, ce combinedEvent) *event {
 			}
 
 			if out.state.MessageSender != nil {
-				err := out.state.MessageSender.populateEvent(p)
+				err := out.state.MessageSender.populateEvent(p, 0)
 				if err != nil {
 					panic(err)
 				}
 			}
 			if out.state.Message != nil {
-				err := out.state.Message.populateEvent(p)
+				err := out.state.Message.populateEvent(p, 0)
 				if err != nil {
 					panic(err)
 				}

--- a/slack/modal.go
+++ b/slack/modal.go
@@ -119,13 +119,13 @@ func (m *modal) finishEvent(req request) error {
 	return nil
 }
 
-func (m *modal) populateEvent(p eventPopulation) error {
+func (m *modal) populateEvent(p eventPopulation, depth int) error {
 	if m.Blocks == nil {
 		m.Blocks = &Blocks{}
 	}
 
 	if m.Submission != nil {
-		return m.Submission.populateEvent(p)
+		return m.Submission.populateEvent(p, depth+1)
 	}
 
 	m.ViewExternalID = p.interactionCallbackEvent.View.ExternalID
@@ -186,12 +186,12 @@ func (m *modalSubmission) finishEvent(req request) error {
 	return nil
 }
 
-func (m *modalSubmission) populateEvent(p eventPopulation) error {
+func (m *modalSubmission) populateEvent(p eventPopulation, depth int) error {
 	if m.NextModal != nil {
-		return m.NextModal.populateEvent(p)
+		return m.NextModal.populateEvent(p, depth+1)
 	}
 	if m.ephemeralSender.Text != nil {
-		return m.ephemeralSender.populateEvent(p)
+		return m.ephemeralSender.populateEvent(p, depth+1)
 	}
 
 	return nil

--- a/slack/slashcommand.go
+++ b/slack/slashcommand.go
@@ -43,12 +43,12 @@ func (is *slashCommand) finishEvent(req request) error {
 	return nil
 }
 
-func (is *slashCommand) populateEvent(p eventPopulation) error {
+func (is *slashCommand) populateEvent(p eventPopulation, depth int) error {
 	if is.ModalInternal != nil {
-		return is.ModalInternal.populateEvent(p)
+		return is.ModalInternal.populateEvent(p, depth+1)
 	}
 	if is.ephemeralSender.Text != nil {
-		return is.ephemeralSender.populateEvent(p)
+		return is.ephemeralSender.populateEvent(p, depth+1)
 	}
 	return nil
 }


### PR DESCRIPTION
This adds the concept of "depth" to events, which allows the origin of an interaction to be attributed to a message without having to store the timestamp.

Fixes #17