### PR TITLE
Create a single test client

### DIFF
--- a/slack/app_test.go
+++ b/slack/app_test.go
@@ -1,25 +1,16 @@
 package slack
 
 import (
-	"context"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/slack-go/slack"
-	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
 	"github.com/theothertomelliott/spanner"
 )
 
 func TestHandlerIsCalledForEachEvent(t *testing.T) {
-	slackEvents := make(chan socketmode.Event, 10)
-	client := newRunSocketClient()
-
-	testApp := newAppWithClient(
-		client,
-		slackEvents,
-	)
+	client := newTestClient()
+	testApp := client.CreateApp()
 
 	results := make(chan struct{}, 2)
 
@@ -33,7 +24,7 @@ func TestHandlerIsCalledForEachEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		var eventType string
 		if i%2 == 0 {
-			slackEvents <- socketmode.Event{}
+			client.SendEventToApp(socketmode.Event{})
 			eventType = "slack"
 		} else {
 			testApp.SendCustom(NewCustomEvent(map[string]interface{}{}))
@@ -48,74 +39,5 @@ func TestHandlerIsCalledForEachEvent(t *testing.T) {
 
 	if client.runCount != 1 {
 		t.Errorf("expected run to be called exactly once")
-	}
-}
-
-func newRunSocketClient() *runSocketClient {
-	return &runSocketClient{
-		stop: make(chan struct{}),
-	}
-}
-
-type runSocketClient struct {
-	nilSocketClient
-
-	runMtx   sync.Mutex
-	runCount int
-
-	stop chan struct{}
-}
-
-func (r *runSocketClient) RunContext(context.Context) error {
-	r.runMtx.Lock()
-	r.runCount++
-	r.runMtx.Unlock()
-	<-r.stop // Must block
-	return nil
-}
-
-func (*runSocketClient) Ack(req socketmode.Request, payload ...interface{}) {}
-
-func messageEvent(messageEvent slackevents.MessageEvent) socketmode.Event {
-	return socketmode.Event{
-		Type: socketmode.EventTypeEventsAPI,
-		Data: slackevents.EventsAPIEvent{
-			Type: slackevents.CallbackEvent,
-			InnerEvent: slackevents.EventsAPIInnerEvent{
-				Data: &messageEvent,
-			},
-		},
-	}
-}
-
-func slashCommandEvent(data slack.SlashCommand) socketmode.Event {
-	return socketmode.Event{
-		Type: socketmode.EventTypeSlashCommand,
-		Data: data,
-	}
-}
-
-func messageInteractionEvent(
-	hash string,
-	timestamp string,
-	metadata slack.SlackMetadata,
-	actionCallbacks slack.ActionCallbacks,
-	blockActionState *slack.BlockActionStates,
-) socketmode.Event {
-	return socketmode.Event{
-		Type: socketmode.EventTypeInteractive,
-		Data: slack.InteractionCallback{
-			ViewSubmissionCallback: slack.ViewSubmissionCallback{
-				Hash: hash,
-			},
-			Message: slack.Message{
-				Msg: slack.Msg{
-					Metadata:  metadata,
-					Timestamp: timestamp,
-				},
-			},
-			ActionCallback:   actionCallbacks,
-			BlockActionState: blockActionState,
-		},
 	}
 }

--- a/slack/examples_test.go
+++ b/slack/examples_test.go
@@ -1,7 +1,6 @@
 package slack
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -9,25 +8,14 @@ import (
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
-	"github.com/slack-go/slack/socketmode"
 	"github.com/theothertomelliott/spanner"
 )
 
 // TestGettingStarted verifies that the code in examples/gettingstarted
 // interacts with Slack in the expected way
 func TestGettingStarted(t *testing.T) {
-	slackEvents := make(chan socketmode.Event)
-	client := newExampleTestClient()
-
-	testApp := newAppWithClient(
-		client,
-		slackEvents,
-	)
-
-	postEvent := make(chan interface{}, 10)
-	testApp.SetPostEventFunc(func() {
-		postEvent <- struct{}{}
-	})
+	client := newTestClient()
+	testApp := client.CreateApp()
 
 	go func() {
 		err := testApp.Run(handler)
@@ -37,16 +25,13 @@ func TestGettingStarted(t *testing.T) {
 	}()
 
 	// Send hello message
-	slackEvents <- messageEvent(
+	client.SendEventToApp(messageEvent(
 		slackevents.MessageEvent{
 			Text:    "hello",
 			Channel: "ABC123",
 			User:    "DEF456",
 		},
-	)
-
-	// Wait for event to be handled
-	<-postEvent
+	))
 
 	// Expect a single message and clear the message list
 	if len(client.messagesSent) != 1 {
@@ -61,7 +46,7 @@ func TestGettingStarted(t *testing.T) {
 	}
 
 	// Select an option value
-	slackEvents <- messageInteractionEvent(
+	client.SendEventToApp(messageInteractionEvent(
 		"hash",
 		"timestamp",
 		msg.metadata,
@@ -77,10 +62,7 @@ func TestGettingStarted(t *testing.T) {
 				},
 			},
 		},
-	)
-
-	// Wait for event to be handled
-	<-postEvent
+	))
 
 	if len(client.messagesSent) != 1 {
 		t.Errorf("expected one message to be sent, got %d", len(client.messagesSent))
@@ -106,58 +88,4 @@ func handler(ev spanner.Event) error {
 		}
 	}
 	return nil
-}
-
-func newExampleTestClient() *exampleTestClient {
-	return &exampleTestClient{
-		stop: make(chan struct{}),
-	}
-}
-
-type exampleTestClient struct {
-	nilSocketClient
-
-	messagesSent    []sentMessage
-	messagesUpdated []updatedMessage
-
-	stop chan struct{}
-}
-
-type sentMessage struct {
-	channelID string
-	blocks    []slack.Block
-	metadata  slack.SlackMetadata
-}
-
-type updatedMessage struct {
-	sentMessage
-	timestamp string
-}
-
-func (r *exampleTestClient) RunContext(context.Context) error {
-	<-r.stop // Must block
-	return nil
-}
-
-func (*exampleTestClient) Ack(req socketmode.Request, payload ...interface{}) {}
-
-func (c *exampleTestClient) SendMessageWithMetadata(ctx context.Context, channelID string, blocks []slack.Block, metadata slack.SlackMetadata) (string, string, string, error) {
-	c.messagesSent = append(c.messagesSent, sentMessage{
-		channelID: channelID,
-		blocks:    blocks,
-		metadata:  metadata,
-	})
-	return "", "", "", nil
-}
-
-func (c *exampleTestClient) UpdateMessageWithMetadata(ctx context.Context, channelID string, timestamp string, blocks []slack.Block, metadata slack.SlackMetadata) (string, string, string, error) {
-	c.messagesUpdated = append(c.messagesUpdated, updatedMessage{
-		sentMessage: sentMessage{
-			channelID: channelID,
-			blocks:    blocks,
-			metadata:  metadata,
-		},
-		timestamp: timestamp,
-	})
-	return "", timestamp, "", nil
 }

--- a/slack/receivemessage_test.go
+++ b/slack/receivemessage_test.go
@@ -4,25 +4,19 @@ import (
 	"testing"
 
 	"github.com/slack-go/slack/slackevents"
-	"github.com/slack-go/slack/socketmode"
 	"github.com/theothertomelliott/spanner"
 )
 
 func TestReceiveMessageContent(t *testing.T) {
-	slackEvents := make(chan socketmode.Event, 10)
-	client := newRunSocketClient()
-
-	testApp := newAppWithClient(
-		client,
-		slackEvents,
-	)
+	client := newTestClient()
+	testApp := client.CreateApp()
 
 	message := slackevents.MessageEvent{
 		Channel: "ABC123",
 		User:    "DEF456",
 		Text:    "hello, there",
 	}
-	slackEvents <- messageEvent(message)
+	client.SendEventToAppAsync(messageEvent(message))
 
 	testApp.Run(func(evt spanner.Event) error {
 		defer func() {

--- a/slack/receiveslashcommand_test.go
+++ b/slack/receiveslashcommand_test.go
@@ -4,18 +4,12 @@ import (
 	"testing"
 
 	"github.com/slack-go/slack"
-	"github.com/slack-go/slack/socketmode"
 	"github.com/theothertomelliott/spanner"
 )
 
 func TestReceiveSlashCommand(t *testing.T) {
-	slackEvents := make(chan socketmode.Event, 10)
-	client := newRunSocketClient()
-
-	testApp := newAppWithClient(
-		client,
-		slackEvents,
-	)
+	client := newTestClient()
+	testApp := client.CreateApp()
 
 	slashCommand := slack.SlashCommand{
 		ChannelID: "ABC123",
@@ -23,9 +17,9 @@ func TestReceiveSlashCommand(t *testing.T) {
 		TriggerID: "trigger",
 		Command:   "/mycommand",
 	}
-	slackEvents <- slashCommandEvent(
+	client.SendEventToAppAsync(slashCommandEvent(
 		slashCommand,
-	)
+	))
 
 	testApp.Run(func(evt spanner.Event) error {
 		defer func() {

--- a/slack/slackclient_test.go
+++ b/slack/slackclient_test.go
@@ -1,0 +1,153 @@
+package slack
+
+import (
+	"context"
+	"sync"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+	"github.com/theothertomelliott/spanner"
+)
+
+func newTestClient() *testClient {
+	return &testClient{
+		Events:    make(chan socketmode.Event),
+		stop:      make(chan struct{}),
+		postEvent: make(chan interface{}, 10),
+	}
+}
+
+type testClient struct {
+	nilSocketClient
+
+	messagesSent    []sentMessage
+	messagesUpdated []updatedMessage
+
+	Events chan socketmode.Event
+
+	postEvent chan interface{}
+
+	stop chan struct{}
+
+	runMtx   sync.Mutex
+	runCount int
+}
+
+type sentMessage struct {
+	channelID string
+	blocks    []slack.Block
+	metadata  slack.SlackMetadata
+}
+
+type updatedMessage struct {
+	sentMessage
+	timestamp string
+}
+
+// CreateApp returns a spanner.App that uses this client
+func (r *testClient) CreateApp() spanner.App {
+	testApp := newAppWithClient(
+		r,
+		r.Events,
+	)
+
+	testApp.SetPostEventFunc(r.PostEventFunc)
+
+	return testApp
+}
+
+// PostEventFunc provides a spanner.PostEventFunc to use with a test app
+// This is automatically applied by the CreateApp function
+func (r *testClient) PostEventFunc() {
+	r.postEvent <- struct{}{}
+}
+
+// SendEventToApp sends an event to the connected app (created with CreateApp)
+// and blocks until the event is handled.
+func (r *testClient) SendEventToApp(e socketmode.Event) {
+	r.Events <- e
+	<-r.postEvent
+}
+
+// SendEventToAppAsync sends an event without blocking.
+func (r *testClient) SendEventToAppAsync(e socketmode.Event) {
+	go func() {
+		r.Events <- e
+	}()
+}
+
+func (r *testClient) RunContext(context.Context) error {
+	r.runMtx.Lock()
+	r.runCount++
+	r.runMtx.Unlock()
+	<-r.stop // Must block
+	return nil
+}
+
+func (*testClient) Ack(req socketmode.Request, payload ...interface{}) {}
+
+func (c *testClient) SendMessageWithMetadata(ctx context.Context, channelID string, blocks []slack.Block, metadata slack.SlackMetadata) (string, string, string, error) {
+	c.messagesSent = append(c.messagesSent, sentMessage{
+		channelID: channelID,
+		blocks:    blocks,
+		metadata:  metadata,
+	})
+	return "", "", "", nil
+}
+
+func (c *testClient) UpdateMessageWithMetadata(ctx context.Context, channelID string, timestamp string, blocks []slack.Block, metadata slack.SlackMetadata) (string, string, string, error) {
+	c.messagesUpdated = append(c.messagesUpdated, updatedMessage{
+		sentMessage: sentMessage{
+			channelID: channelID,
+			blocks:    blocks,
+			metadata:  metadata,
+		},
+		timestamp: timestamp,
+	})
+	return "", timestamp, "", nil
+}
+
+func messageEvent(messageEvent slackevents.MessageEvent) socketmode.Event {
+	return socketmode.Event{
+		Type: socketmode.EventTypeEventsAPI,
+		Data: slackevents.EventsAPIEvent{
+			Type: slackevents.CallbackEvent,
+			InnerEvent: slackevents.EventsAPIInnerEvent{
+				Data: &messageEvent,
+			},
+		},
+	}
+}
+
+func slashCommandEvent(data slack.SlashCommand) socketmode.Event {
+	return socketmode.Event{
+		Type: socketmode.EventTypeSlashCommand,
+		Data: data,
+	}
+}
+
+func messageInteractionEvent(
+	hash string,
+	timestamp string,
+	metadata slack.SlackMetadata,
+	actionCallbacks slack.ActionCallbacks,
+	blockActionState *slack.BlockActionStates,
+) socketmode.Event {
+	return socketmode.Event{
+		Type: socketmode.EventTypeInteractive,
+		Data: slack.InteractionCallback{
+			ViewSubmissionCallback: slack.ViewSubmissionCallback{
+				Hash: hash,
+			},
+			Message: slack.Message{
+				Msg: slack.Msg{
+					Metadata:  metadata,
+					Timestamp: timestamp,
+				},
+			},
+			ActionCallback:   actionCallbacks,
+			BlockActionState: blockActionState,
+		},
+	}
+}


### PR DESCRIPTION
This simplifies unit tests and will make them easier to extend in future.