### PR TITLE
Add the concept of an "action" to the app

### DIFF
--- a/action.go
+++ b/action.go
@@ -1,0 +1,6 @@
+package spanner
+
+type Action interface {
+	Type() string
+	Data() interface{}
+}

--- a/slack/action.go
+++ b/slack/action.go
@@ -1,0 +1,22 @@
+package slack
+
+import (
+	"context"
+
+	"github.com/theothertomelliott/spanner"
+)
+
+type action interface {
+	spanner.Action
+
+	// exec performs and action and returns a payload to acknowledge the request as appropriate
+	exec(ctx context.Context, req request) (interface{}, error)
+}
+
+type actionQueue struct {
+	actions []action
+}
+
+func (a *actionQueue) enqueue(ac action) {
+	a.actions = append(a.actions, ac)
+}

--- a/slack/channel.go
+++ b/slack/channel.go
@@ -41,3 +41,28 @@ func (c *channel) load(ctx context.Context) {
 	c.Loaded = true
 	c.NameInternal = ch.Name
 }
+
+var _ action = &joinChannelAction{}
+
+type joinChannelAction struct {
+	channelID string
+}
+
+// Data implements action.
+func (*joinChannelAction) Data() interface{} {
+	panic("unimplemented")
+}
+
+// Type implements action.
+func (*joinChannelAction) Type() string {
+	return "join_channel"
+}
+
+// exec implements action.
+func (a *joinChannelAction) exec(ctx context.Context, req request) (interface{}, error) {
+	_, _, _, err := req.client.JoinConversationContext(ctx, a.channelID)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/slack/ephemeral.go
+++ b/slack/ephemeral.go
@@ -8,26 +8,44 @@ import (
 
 var _ spanner.EphemeralSender = &ephemeralSender{}
 var _ eventPopulator = &ephemeralSender{}
-var _ eventFinisher = &ephemeralSender{}
 
 type ephemeralSender struct {
+	actionQueue *actionQueue
+
 	Text *string `json:"ephemeral"`
 }
 
 // SendEphemeralMessage implements spanner.EphemeralSender.
 func (es *ephemeralSender) SendEphemeralMessage(text string) {
-	es.Text = &text
-}
-
-func (es *ephemeralSender) finishEvent(ctx context.Context, req request) error {
-	payload := map[string]interface{}{
-		"text": es.Text,
-	}
-	req.client.Ack(req.req, payload)
-
-	return nil
+	es.actionQueue.enqueue(&sendEphemeralMessageAction{
+		text: text,
+	})
 }
 
 func (es *ephemeralSender) populateEvent(ctx context.Context, p eventPopulation, depth int) error {
 	return nil
+}
+
+var _ action = &sendEphemeralMessageAction{}
+
+type sendEphemeralMessageAction struct {
+	text string
+}
+
+// Data implements action.
+func (*sendEphemeralMessageAction) Data() interface{} {
+	panic("unimplemented")
+}
+
+// Type implements action.
+func (*sendEphemeralMessageAction) Type() string {
+	return "ephemeral-message"
+}
+
+// exec implements action.
+func (e *sendEphemeralMessageAction) exec(ctx context.Context, req request) (interface{}, error) {
+	payload := map[string]interface{}{
+		"text": e.text,
+	}
+	return payload, nil
 }

--- a/slack/slashcommand.go
+++ b/slack/slashcommand.go
@@ -7,6 +7,8 @@ import (
 )
 
 type slashCommand struct {
+	actionQueue *actionQueue
+
 	eventMetadata
 	ephemeralSender
 
@@ -17,7 +19,6 @@ type slashCommand struct {
 
 var _ spanner.SlashCommand = &slashCommand{}
 var _ eventPopulator = &slashCommand{}
-var _ eventFinisher = &slashCommand{}
 
 func (is *slashCommand) Modal(title string) spanner.Modal {
 	if is == nil {
@@ -32,21 +33,8 @@ func (is *slashCommand) Modal(title string) spanner.Modal {
 		Title:     title,
 		triggerID: is.TriggerID,
 	}
+	is.actionQueue.enqueue(is.ModalInternal)
 	return is.ModalInternal
-}
-
-func (is *slashCommand) finishEvent(ctx context.Context, req request) error {
-	if is.ModalInternal != nil {
-		return is.ModalInternal.finishEvent(ctx, req)
-	}
-	if is.ephemeralSender.Text != nil {
-		return is.ephemeralSender.finishEvent(ctx, req)
-	}
-
-	var payload interface{} = map[string]interface{}{}
-	req.client.Ack(req.req, payload)
-
-	return nil
 }
 
 func (is *slashCommand) populateEvent(ctx context.Context, p eventPopulation, depth int) error {


### PR DESCRIPTION
A queue of actions is built up during an event and executed in order at the end of the event. This avoids having to walk the whole tree and makes it easie to manage common functions.

With event types and data as strings, it will also make it possible to create a simple interceptor for instrumentation.