### PR TITLE
Add errors to actions to allow for custom handling

### DIFF
--- a/action.go
+++ b/action.go
@@ -3,6 +3,8 @@ package spanner
 import "context"
 
 type Action interface {
+	HasError
+
 	Type() string
 	Data() interface{}
 }

--- a/api.go
+++ b/api.go
@@ -51,6 +51,7 @@ type SlashCommand interface {
 // It can be used to create blocks and handle submission or closing of the modal.
 type Modal interface {
 	BlockUI
+
 	SubmitButton(title string) ModalSubmission
 	CloseButton(title string) bool
 }
@@ -75,6 +76,14 @@ type EphemeralSender interface {
 // Messages are constructed using BlockUI commands.
 type Message interface {
 	BlockUI
+	HasError
+
+	Channel(channelID string)
+}
+
+type NonInteractiveMessage interface {
+	NonInteractiveBlockUI
+	HasError
 
 	Channel(channelID string)
 }

--- a/blocks.go
+++ b/blocks.go
@@ -2,9 +2,17 @@ package spanner
 
 // BlockUI allows the creation of Slack blocks in a message or modal.
 type BlockUI interface {
+	NonInteractiveBlockUI
+	InteractiveBlockUI
+}
+
+type NonInteractiveBlockUI interface {
 	Header(message string)
 	PlainText(text string)
 	Markdown(text string)
+}
+
+type InteractiveBlockUI interface {
 	TextInput(label string, hint string, placeholder string) string
 	MultilineTextInput(label string, hint string, placeholder string) string
 	Divider()

--- a/error.go
+++ b/error.go
@@ -1,0 +1,18 @@
+package spanner
+
+import "context"
+
+type HasError interface {
+	ErrorFunc(ErrorFunc)
+}
+
+type ErrorFunc func(ctx context.Context, ev ErrorEvent)
+
+type ErrorEvent interface {
+	SendMessage(channelID string) ErrorMessage
+	ReceiveError() error
+}
+
+type ErrorMessage interface {
+	NonInteractiveMessage
+}

--- a/slack/action.go
+++ b/slack/action.go
@@ -11,6 +11,8 @@ type action interface {
 
 	// exec performs and action and returns a payload to acknowledge the request as appropriate
 	exec(ctx context.Context, req request) (interface{}, error)
+
+	getErrorFunc() spanner.ErrorFunc
 }
 
 type actionQueue struct {

--- a/slack/app_test.go
+++ b/slack/app_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestHandlerIsCalledForEachEvent(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient([]string{"ABC123"})
 	testApp := client.CreateApp()
 
 	results := make(chan struct{}, 2)

--- a/slack/channel.go
+++ b/slack/channel.go
@@ -46,6 +46,15 @@ var _ action = &joinChannelAction{}
 
 type joinChannelAction struct {
 	channelID string
+	errFunc   spanner.ErrorFunc
+}
+
+func (j *joinChannelAction) ErrorFunc(ef spanner.ErrorFunc) {
+	j.errFunc = ef
+}
+
+func (j *joinChannelAction) getErrorFunc() spanner.ErrorFunc {
+	return j.errFunc
 }
 
 // Data implements action.

--- a/slack/ephemeral.go
+++ b/slack/ephemeral.go
@@ -30,6 +30,16 @@ var _ action = &sendEphemeralMessageAction{}
 
 type sendEphemeralMessageAction struct {
 	text string
+
+	errFunc spanner.ErrorFunc
+}
+
+func (e *sendEphemeralMessageAction) ErrorFunc(ef spanner.ErrorFunc) {
+	e.errFunc = ef
+}
+
+func (e *sendEphemeralMessageAction) getErrorFunc() spanner.ErrorFunc {
+	return e.errFunc
 }
 
 // Data implements action.

--- a/slack/error_test.go
+++ b/slack/error_test.go
@@ -1,0 +1,73 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack/slackevents"
+	"github.com/theothertomelliott/spanner"
+)
+
+// TestErrorHandling verifies that error handlers are called appropriately
+func TestErrorHandling(t *testing.T) {
+	client := newTestClient([]string{"ABC123"})
+	testApp := client.CreateApp()
+
+	go func() {
+		err := testApp.Run(handlerTestErrors)
+		if err != nil {
+			t.Errorf("error running app: %v", err)
+		}
+	}()
+
+	// Send hello message
+	client.SendEventToApp(messageEvent(
+		slackevents.MessageEvent{
+			Text:    "hello",
+			Channel: "ABC123",
+			User:    "DEF456",
+		},
+	))
+
+	// Expect a single message and clear the message list
+	if len(client.messagesSent) != 2 {
+		t.Errorf("expected two messages to be sent, got %d", len(client.messagesSent))
+	}
+
+	firstBlocks, _ := json.MarshalIndent(client.messagesSent[0].blocks, "", "  ")
+	if !strings.Contains(string(firstBlocks), `This message should succeed`) {
+		t.Errorf("first message content was not as expected, got: %v", string(firstBlocks))
+	}
+
+	secondBlocks, _ := json.MarshalIndent(client.messagesSent[1].blocks, "", "  ")
+	if !strings.Contains(string(secondBlocks), `There was an error sending a message`) {
+		t.Errorf("first message content was not as expected, got: %v", string(secondBlocks))
+	}
+}
+
+func handlerTestErrors(ctx context.Context, ev spanner.Event) error {
+	if msg := ev.ReceiveMessage(); msg != nil && msg.Text() == "hello" {
+		replyGood := ev.SendMessage(msg.Channel().ID())
+		replyGood.PlainText("This message should succeed")
+		replyGood.ErrorFunc(func(ctx context.Context, ev spanner.ErrorEvent) {
+			panic("did not expect this message to fail")
+		})
+
+		replyBad := ev.SendMessage("invalid_channel")
+		replyBad.PlainText("This message will always fail to post")
+		replyBad.ErrorFunc(func(ctx context.Context, ev spanner.ErrorEvent) {
+			errorNotice := ev.SendMessage(msg.Channel().ID())
+			errorNotice.PlainText(fmt.Sprintf("There was an error sending a message: %v", ev.ReceiveError()))
+		})
+
+		replySkipped := ev.SendMessage(msg.Channel().ID())
+		replySkipped.PlainText("This message should be skipped because of the previous error")
+		replySkipped.ErrorFunc(func(ctx context.Context, ev spanner.ErrorEvent) {
+			panic("did not expect this message to fail")
+		})
+	}
+	return nil
+}

--- a/slack/errors.go
+++ b/slack/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/slack-go/slack"
+	"github.com/theothertomelliott/spanner"
 )
 
 func renderSlackError(err error) error {
@@ -15,4 +16,33 @@ func renderSlackError(err error) error {
 		return fmt.Errorf("%w %v %v", slackErr, slackErr.ResponseMetadata.Messages, slackErr.ResponseMetadata.Warnings)
 	}
 	return err
+}
+
+var _ spanner.ErrorEvent = &errorEvent{}
+
+func newErrorEvent(err error) *errorEvent {
+	q := &actionQueue{}
+	return &errorEvent{
+		actionQueue: q,
+		sender: &MessageSender{
+			actionQueue: q,
+		},
+		err: err,
+	}
+}
+
+type errorEvent struct {
+	actionQueue *actionQueue
+	sender      *MessageSender
+
+	err error
+}
+
+func (e *errorEvent) SendMessage(channelID string) spanner.ErrorMessage {
+	return e.sender.SendMessage(channelID)
+}
+
+// ReceiveError implements spanner.ErrorEvent.
+func (e *errorEvent) ReceiveError() error {
+	return e.err
 }

--- a/slack/examples_test.go
+++ b/slack/examples_test.go
@@ -15,7 +15,7 @@ import (
 // TestGettingStarted verifies that the code in examples/gettingstarted
 // interacts with Slack in the expected way
 func TestGettingStarted(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient([]string{"ABC123"})
 	testApp := client.CreateApp()
 
 	go func() {

--- a/slack/message.go
+++ b/slack/message.go
@@ -36,6 +36,16 @@ type message struct {
 	currentEventDepth   int
 	actionMessageTS     string
 	unsent              bool
+
+	errFunc spanner.ErrorFunc
+}
+
+func (m *message) ErrorFunc(ef spanner.ErrorFunc) {
+	m.errFunc = ef
+}
+
+func (m *message) getErrorFunc() spanner.ErrorFunc {
+	return m.errFunc
 }
 
 func (m *message) Type() string {

--- a/slack/modal.go
+++ b/slack/modal.go
@@ -31,6 +31,16 @@ type modal struct {
 
 	submitText *string
 	closeText  *string
+
+	errFunc spanner.ErrorFunc
+}
+
+func (m *modal) ErrorFunc(ef spanner.ErrorFunc) {
+	m.errFunc = ef
+}
+
+func (m *modal) getErrorFunc() spanner.ErrorFunc {
+	return m.errFunc
 }
 
 type updateType int
@@ -175,6 +185,16 @@ type modalSubmission struct {
 	NextModal *modal `json:"next_modal"`
 
 	parent *modal
+
+	errFunc spanner.ErrorFunc
+}
+
+func (m *modalSubmission) ErrorFunc(ef spanner.ErrorFunc) {
+	m.errFunc = ef
+}
+
+func (m *modalSubmission) getErrorFunc() spanner.ErrorFunc {
+	return m.errFunc
 }
 
 func (m *modalSubmission) PushModal(title string) spanner.Modal {

--- a/slack/receivemessage_test.go
+++ b/slack/receivemessage_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReceiveMessageContent(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient([]string{"ABC123"})
 	testApp := client.CreateApp()
 
 	message := slackevents.MessageEvent{

--- a/slack/receiveslashcommand_test.go
+++ b/slack/receiveslashcommand_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReceiveSlashCommand(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient([]string{"ABC123"})
 	testApp := client.CreateApp()
 
 	slashCommand := slack.SlashCommand{


### PR DESCRIPTION
Actions now allow you to specify an error handling function (via the ErrorFunc function).

The error handlers can post messages without interactive elements.

Unit tests have been added for this path.

Fixes #31
Fixes #10